### PR TITLE
modify AdjustmentLayer super class

### DIFF
--- a/src/psd_tools/user_api/psd_image.py
+++ b/src/psd_tools/user_api/psd_image.py
@@ -257,7 +257,7 @@ class _VisibleLayer(_RawLayer):
                 bbox.x1, bbox.y1, self.visible, self.mask, self.effects))
 
 
-class AdjustmentLayer(_RawLayer):
+class AdjustmentLayer(_VisibleLayer):
     """PSD adjustment layer wrapper."""
     def __init__(self, parent, index):
         super(AdjustmentLayer, self).__init__(parent, index, 'adjustment')


### PR DESCRIPTION
Workaround for the following exceptions:
- `AttributeError: 'AdjustmentLayer' object has no attribute 'bbox'` 
- `AttributeError: 'AdjustmentLayer' object has no attribute 'as_PIL'`
