### PR TITLE
add `bbox` property to `AdjustmentLayer`

### DIFF
--- a/src/psd_tools/user_api/psd_image.py
+++ b/src/psd_tools/user_api/psd_image.py
@@ -266,6 +266,12 @@ class AdjustmentLayer(_RawLayer):
         return "<%s: %r, visible=%s>" % (
             self.__class__.__name__, self.name, self.visible)
 
+    @property
+    def bbox(self):
+        """BBox(x1, y1, x2, y2) namedtuple with layer bounding box."""
+        info = self._info
+        return BBox(info.left, info.top, info.right, info.bottom)
+
 
 class PixelLayer(_VisibleLayer):
     """PSD pixel layer wrapper."""


### PR DESCRIPTION
add `bbox` property to `AdjustmentLayer`, for the following reasons:
- some fill type `AdjustmentLayer`s have bbox
- all layer objects are expected to have `bbox` property in psd_image.py
    - https://github.com/kyamagu/psd-tools2/blob/5b0050d2427b1ef32251e16dc73ef1c71b22de21/src/psd_tools/user_api/psd_image.py#L682