### PR TITLE
Get the correct initial mask image.

### DIFF
--- a/src/psd_tools/user_api/composer.py
+++ b/src/psd_tools/user_api/composer.py
@@ -106,7 +106,7 @@ def compose(layers, respect_visibility=True, ignore_blend_mode=True,
         if layer.has_mask():
             mask_box = layer.mask.bbox
             if not layer.mask.disabled and not mask_box.is_empty():
-                mask = Image.new("L", layer_image.size, color=(0,))
+                mask = Image.new("L", layer_image.size, color=(255,))
                 mask.paste(
                     layer.mask.as_PIL(),
                     mask_box.offset((layer.bbox.x1, layer.bbox.y1))


### PR DESCRIPTION
Fixed an issue that mask unapplied part was transparent when getting mask image.